### PR TITLE
WEZ presets: add 17 heat-generator datapoints verified on an UltraSource B comfort C17

### DIFF
--- a/esphome/components/toptronic/presets/WEZ/sensors_de.yaml
+++ b/esphome/components/toptronic/presets/WEZ/sensors_de.yaml
@@ -367,6 +367,271 @@ sensor:
     device_class: temperature
     state_class: measurement
     internal: true
+
+  # ---------------------------------------------------------------------------
+  # Verified on an independent UltraSource B comfort C17 (TTE-WEZ, commissioned
+  # 2021) via CAN GET plus 5-minute long-term logging, cross-checked against the
+  # energy counters and Hoval's own Modbus register list.
+  # Evidence and raw CSVs: https://github.com/newstedaut/hoval_datapoints
+  # ---------------------------------------------------------------------------
+  - platform: toptronic
+    name: COP aktuell
+    device_type: WEZ
+    function_group: 60
+    function_number: 254
+    datapoint: 45
+    id: WEZ_60_254_45
+    type: U8
+    accuracy_decimals: 1
+    filters:
+      - multiply: 0.1
+    icon: mdi:gauge
+    state_class: measurement
+    # Live COP while the compressor runs; reads 0 when idle.
+  - platform: toptronic
+    name: Waermemenge Kuehlen
+    device_type: WEZ
+    function_group: 60
+    function_number: 254
+    datapoint: 51
+    id: WEZ_60_254_51
+    type: U32
+    accuracy_decimals: 3
+    filters:
+      - multiply: 0.001
+    unit_of_measurement: MWh
+    icon: mdi:snowflake
+    device_class: energy
+    state_class: measurement
+    # Lifetime cooling energy counter -- the cooling counterpart to dp 47 / dp
+    # 55.
+  - platform: toptronic
+    name: Wasserdruck
+    device_type: WEZ
+    function_group: 60
+    function_number: 254
+    datapoint: 32
+    id: WEZ_60_254_32
+    type: S16
+    accuracy_decimals: 1
+    filters:
+      - multiply: 0.1
+      - lambda: 'return (x < -3000.0f) ? NAN : x;'   # 0x8000 = invalid / no sensor
+    unit_of_measurement: bar
+    icon: mdi:gauge
+    state_class: measurement
+    # Reads 0x8000 (invalid) when no pressure sensor is wired; filtered to NaN
+    # below.
+  - platform: toptronic
+    name: Quelle Vorlauf (Verdampfer ein)
+    device_type: WEZ
+    function_group: 60
+    function_number: 254
+    datapoint: 84
+    id: WEZ_60_254_84
+    type: S16
+    accuracy_decimals: 1
+    filters:
+      - multiply: 0.1
+    unit_of_measurement: "\xB0C"
+    icon: mdi:thermometer
+    device_class: temperature
+    state_class: measurement
+  - platform: toptronic
+    name: Quelle Ruecklauf (Verdampfer Oberflaeche)
+    device_type: WEZ
+    function_group: 60
+    function_number: 254
+    datapoint: 85
+    id: WEZ_60_254_85
+    type: S16
+    accuracy_decimals: 1
+    filters:
+      - multiply: 0.1
+    unit_of_measurement: "\xB0C"
+    icon: mdi:thermometer
+    device_class: temperature
+    state_class: measurement
+  - platform: toptronic
+    name: Laufzeit Heizbetrieb
+    device_type: WEZ
+    function_group: 60
+    function_number: 7
+    datapoint: 1033
+    id: WEZ_60_7_1033
+    type: S32
+    accuracy_decimals: 1
+    filters:
+      - multiply: 0.1
+    unit_of_measurement: h
+    icon: mdi:clock-outline
+    device_class: duration
+    state_class: total_increasing
+    # Scale 0.1 h. Verified: 71.979 MWh / 10156.3 h = 7.1 kW mean output on a 17
+    # kW unit.
+  - platform: toptronic
+    name: Laufzeit Kuehlbetrieb
+    device_type: WEZ
+    function_group: 60
+    function_number: 7
+    datapoint: 1034
+    id: WEZ_60_7_1034
+    type: S32
+    accuracy_decimals: 1
+    filters:
+      - multiply: 0.1
+    unit_of_measurement: h
+    icon: mdi:clock-outline
+    device_class: duration
+    state_class: total_increasing
+    # NOTE: Hoval's own list names this dp "Operating hours DHW" elsewhere --
+    # that name is wrong, the values say cooling.
+  - platform: toptronic
+    name: Laufzeit Warmwasser
+    device_type: WEZ
+    function_group: 60
+    function_number: 7
+    datapoint: 1035
+    id: WEZ_60_7_1035
+    type: S32
+    accuracy_decimals: 1
+    filters:
+      - multiply: 0.1
+    unit_of_measurement: h
+    icon: mdi:clock-outline
+    device_class: duration
+    state_class: total_increasing
+    # NOTE: same name collision as dp 1034, in the other direction.
+  - platform: toptronic
+    name: Schaltzyklen Waermeerzeuger (gesamt)
+    device_type: WEZ
+    function_group: 10
+    function_number: 1
+    datapoint: 2080
+    id: WEZ_10_1_2080
+    type: U32
+    accuracy_decimals: 0
+    icon: mdi:counter
+    state_class: total_increasing
+    # TOTAL starts. Do not confuse with dp 2083, which only counts starts above
+    # 50 % modulation (~2.4x lower).
+  - platform: toptronic
+    name: Betriebsstunden Waermeerzeuger
+    device_type: WEZ
+    function_group: 10
+    function_number: 1
+    datapoint: 2081
+    id: WEZ_10_1_2081
+    type: U32
+    accuracy_decimals: 0
+    unit_of_measurement: h
+    icon: mdi:clock-outline
+    device_class: duration
+    state_class: total_increasing
+    # Appears twice in Hoval's register list (two mirrored register pairs), same
+    # value.
+  - platform: toptronic
+    name: Betriebsstunden ueber 50% Modulation
+    device_type: WEZ
+    function_group: 10
+    function_number: 1
+    datapoint: 2082
+    id: WEZ_10_1_2082
+    type: U32
+    accuracy_decimals: 0
+    unit_of_measurement: h
+    icon: mdi:clock-outline
+    device_class: duration
+    state_class: total_increasing
+  - platform: toptronic
+    name: Schaltzyklen ueber 50% Modulation
+    device_type: WEZ
+    function_group: 10
+    function_number: 1
+    datapoint: 2083
+    id: WEZ_10_1_2083
+    type: U32
+    accuracy_decimals: 0
+    icon: mdi:counter
+    state_class: total_increasing
+  - platform: toptronic
+    name: Anlageleistung-Sollwert Heizen
+    device_type: WEZ
+    function_group: 3
+    function_number: 0
+    datapoint: 2040
+    id: WEZ_3_0_2040
+    type: S16
+    accuracy_decimals: 1
+    filters:
+      - multiply: 0.1
+      - lambda: 'return (x <= -126.5f) ? NAN : x;'   # -127.0 = invalid marker
+    unit_of_measurement: '%'
+    icon: mdi:percent
+    state_class: measurement
+    # -100.0 = this channel requests nothing (valid reading). -127.0 = invalid,
+    # filtered to NaN.
+  - platform: toptronic
+    name: Anlageleistung-Sollwert Warmwasser
+    device_type: WEZ
+    function_group: 3
+    function_number: 0
+    datapoint: 2041
+    id: WEZ_3_0_2041
+    type: S16
+    accuracy_decimals: 1
+    filters:
+      - multiply: 0.1
+      - lambda: 'return (x <= -126.5f) ? NAN : x;'   # -127.0 = invalid marker
+    unit_of_measurement: '%'
+    icon: mdi:percent
+    state_class: measurement
+  - platform: toptronic
+    name: Anlageleistung-Sollwert Kuehlen
+    device_type: WEZ
+    function_group: 3
+    function_number: 0
+    datapoint: 2042
+    id: WEZ_3_0_2042
+    type: S16
+    accuracy_decimals: 1
+    filters:
+      - multiply: 0.1
+      - lambda: 'return (x <= -126.5f) ? NAN : x;'   # -127.0 = invalid marker
+    unit_of_measurement: '%'
+    icon: mdi:percent
+    state_class: measurement
+  - platform: toptronic
+    name: Leistungs-Sollwert Waermeerzeuger
+    device_type: WEZ
+    function_group: 4
+    function_number: 0
+    datapoint: 1009
+    id: WEZ_4_0_1009
+    type: S16
+    accuracy_decimals: 1
+    filters:
+      - multiply: 0.1
+      - lambda: 'return (x <= -126.5f) ? NAN : x;'   # -127.0 = invalid marker
+    unit_of_measurement: '%'
+    icon: mdi:percent
+    state_class: measurement
+    # Equals whichever of dp 2040/2041/2042 is active (99.1 % match over 6587
+    # samples).
+  - platform: toptronic
+    name: Anforderung Waermeerzeuger
+    device_type: WEZ
+    function_group: 4
+    function_number: 0
+    datapoint: 2043
+    id: WEZ_4_0_2043
+    type: U8
+    accuracy_decimals: 0
+    unit_of_measurement: '%'
+    icon: mdi:toggle-switch
+    state_class: measurement
+    # Despite the name this is binary: only 0 or 100 were ever observed.
+
 text_sensor:
   - platform: toptronic
     name: Betriebswahl Heizung (1)
@@ -699,3 +964,4 @@ text_sensor:
       - 1
       - 2
       - 3
+

--- a/esphome/components/toptronic/presets/WEZ/sensors_en.yaml
+++ b/esphome/components/toptronic/presets/WEZ/sensors_en.yaml
@@ -367,6 +367,271 @@ sensor:
     device_class: temperature
     state_class: measurement
     internal: true
+
+  # ---------------------------------------------------------------------------
+  # Verified on an independent UltraSource B comfort C17 (TTE-WEZ, commissioned
+  # 2021) via CAN GET plus 5-minute long-term logging, cross-checked against the
+  # energy counters and Hoval's own Modbus register list.
+  # Evidence and raw CSVs: https://github.com/newstedaut/hoval_datapoints
+  # ---------------------------------------------------------------------------
+  - platform: toptronic
+    name: COP current
+    device_type: WEZ
+    function_group: 60
+    function_number: 254
+    datapoint: 45
+    id: WEZ_60_254_45
+    type: U8
+    accuracy_decimals: 1
+    filters:
+      - multiply: 0.1
+    icon: mdi:gauge
+    state_class: measurement
+    # Live COP while the compressor runs; reads 0 when idle.
+  - platform: toptronic
+    name: Heat quantity cooling
+    device_type: WEZ
+    function_group: 60
+    function_number: 254
+    datapoint: 51
+    id: WEZ_60_254_51
+    type: U32
+    accuracy_decimals: 3
+    filters:
+      - multiply: 0.001
+    unit_of_measurement: MWh
+    icon: mdi:snowflake
+    device_class: energy
+    state_class: measurement
+    # Lifetime cooling energy counter -- the cooling counterpart to dp 47 / dp
+    # 55.
+  - platform: toptronic
+    name: Water pressure
+    device_type: WEZ
+    function_group: 60
+    function_number: 254
+    datapoint: 32
+    id: WEZ_60_254_32
+    type: S16
+    accuracy_decimals: 1
+    filters:
+      - multiply: 0.1
+      - lambda: 'return (x < -3000.0f) ? NAN : x;'   # 0x8000 = invalid / no sensor
+    unit_of_measurement: bar
+    icon: mdi:gauge
+    state_class: measurement
+    # Reads 0x8000 (invalid) when no pressure sensor is wired; filtered to NaN
+    # below.
+  - platform: toptronic
+    name: Source flow (evaporator inlet)
+    device_type: WEZ
+    function_group: 60
+    function_number: 254
+    datapoint: 84
+    id: WEZ_60_254_84
+    type: S16
+    accuracy_decimals: 1
+    filters:
+      - multiply: 0.1
+    unit_of_measurement: "\xB0C"
+    icon: mdi:thermometer
+    device_class: temperature
+    state_class: measurement
+  - platform: toptronic
+    name: Source return (evaporator surface)
+    device_type: WEZ
+    function_group: 60
+    function_number: 254
+    datapoint: 85
+    id: WEZ_60_254_85
+    type: S16
+    accuracy_decimals: 1
+    filters:
+      - multiply: 0.1
+    unit_of_measurement: "\xB0C"
+    icon: mdi:thermometer
+    device_class: temperature
+    state_class: measurement
+  - platform: toptronic
+    name: Heating operation running time
+    device_type: WEZ
+    function_group: 60
+    function_number: 7
+    datapoint: 1033
+    id: WEZ_60_7_1033
+    type: S32
+    accuracy_decimals: 1
+    filters:
+      - multiply: 0.1
+    unit_of_measurement: h
+    icon: mdi:clock-outline
+    device_class: duration
+    state_class: total_increasing
+    # Scale 0.1 h. Verified: 71.979 MWh / 10156.3 h = 7.1 kW mean output on a 17
+    # kW unit.
+  - platform: toptronic
+    name: Cooling operation running time
+    device_type: WEZ
+    function_group: 60
+    function_number: 7
+    datapoint: 1034
+    id: WEZ_60_7_1034
+    type: S32
+    accuracy_decimals: 1
+    filters:
+      - multiply: 0.1
+    unit_of_measurement: h
+    icon: mdi:clock-outline
+    device_class: duration
+    state_class: total_increasing
+    # NOTE: Hoval's own list names this dp "Operating hours DHW" elsewhere --
+    # that name is wrong, the values say cooling.
+  - platform: toptronic
+    name: Hot water operation running time
+    device_type: WEZ
+    function_group: 60
+    function_number: 7
+    datapoint: 1035
+    id: WEZ_60_7_1035
+    type: S32
+    accuracy_decimals: 1
+    filters:
+      - multiply: 0.1
+    unit_of_measurement: h
+    icon: mdi:clock-outline
+    device_class: duration
+    state_class: total_increasing
+    # NOTE: same name collision as dp 1034, in the other direction.
+  - platform: toptronic
+    name: Switching cycles heat generator (total)
+    device_type: WEZ
+    function_group: 10
+    function_number: 1
+    datapoint: 2080
+    id: WEZ_10_1_2080
+    type: U32
+    accuracy_decimals: 0
+    icon: mdi:counter
+    state_class: total_increasing
+    # TOTAL starts. Do not confuse with dp 2083, which only counts starts above
+    # 50 % modulation (~2.4x lower).
+  - platform: toptronic
+    name: Operating hours heat generator
+    device_type: WEZ
+    function_group: 10
+    function_number: 1
+    datapoint: 2081
+    id: WEZ_10_1_2081
+    type: U32
+    accuracy_decimals: 0
+    unit_of_measurement: h
+    icon: mdi:clock-outline
+    device_class: duration
+    state_class: total_increasing
+    # Appears twice in Hoval's register list (two mirrored register pairs), same
+    # value.
+  - platform: toptronic
+    name: Operating hours above 50% modulation
+    device_type: WEZ
+    function_group: 10
+    function_number: 1
+    datapoint: 2082
+    id: WEZ_10_1_2082
+    type: U32
+    accuracy_decimals: 0
+    unit_of_measurement: h
+    icon: mdi:clock-outline
+    device_class: duration
+    state_class: total_increasing
+  - platform: toptronic
+    name: Switching cycles above 50% modulation
+    device_type: WEZ
+    function_group: 10
+    function_number: 1
+    datapoint: 2083
+    id: WEZ_10_1_2083
+    type: U32
+    accuracy_decimals: 0
+    icon: mdi:counter
+    state_class: total_increasing
+  - platform: toptronic
+    name: System output setpoint heating
+    device_type: WEZ
+    function_group: 3
+    function_number: 0
+    datapoint: 2040
+    id: WEZ_3_0_2040
+    type: S16
+    accuracy_decimals: 1
+    filters:
+      - multiply: 0.1
+      - lambda: 'return (x <= -126.5f) ? NAN : x;'   # -127.0 = invalid marker
+    unit_of_measurement: '%'
+    icon: mdi:percent
+    state_class: measurement
+    # -100.0 = this channel requests nothing (valid reading). -127.0 = invalid,
+    # filtered to NaN.
+  - platform: toptronic
+    name: System output setpoint DHW
+    device_type: WEZ
+    function_group: 3
+    function_number: 0
+    datapoint: 2041
+    id: WEZ_3_0_2041
+    type: S16
+    accuracy_decimals: 1
+    filters:
+      - multiply: 0.1
+      - lambda: 'return (x <= -126.5f) ? NAN : x;'   # -127.0 = invalid marker
+    unit_of_measurement: '%'
+    icon: mdi:percent
+    state_class: measurement
+  - platform: toptronic
+    name: System output setpoint cooling
+    device_type: WEZ
+    function_group: 3
+    function_number: 0
+    datapoint: 2042
+    id: WEZ_3_0_2042
+    type: S16
+    accuracy_decimals: 1
+    filters:
+      - multiply: 0.1
+      - lambda: 'return (x <= -126.5f) ? NAN : x;'   # -127.0 = invalid marker
+    unit_of_measurement: '%'
+    icon: mdi:percent
+    state_class: measurement
+  - platform: toptronic
+    name: Set value output heat generator
+    device_type: WEZ
+    function_group: 4
+    function_number: 0
+    datapoint: 1009
+    id: WEZ_4_0_1009
+    type: S16
+    accuracy_decimals: 1
+    filters:
+      - multiply: 0.1
+      - lambda: 'return (x <= -126.5f) ? NAN : x;'   # -127.0 = invalid marker
+    unit_of_measurement: '%'
+    icon: mdi:percent
+    state_class: measurement
+    # Equals whichever of dp 2040/2041/2042 is active (99.1 % match over 6587
+    # samples).
+  - platform: toptronic
+    name: Current request on heat generator
+    device_type: WEZ
+    function_group: 4
+    function_number: 0
+    datapoint: 2043
+    id: WEZ_4_0_2043
+    type: U8
+    accuracy_decimals: 0
+    unit_of_measurement: '%'
+    icon: mdi:toggle-switch
+    state_class: measurement
+    # Despite the name this is binary: only 0 or 100 were ever observed.
+
 text_sensor:
   - platform: toptronic
     name: Heating operation choice (1)
@@ -699,3 +964,4 @@ text_sensor:
       - 1
       - 2
       - 3
+


### PR DESCRIPTION
Follow-up to #50. While mapping the heat-generator level on my own unit I noticed the `WEZ` preset is missing a fair number of datapoints that the controller does answer, so here they are in your format.

**Added (EN + DE):**

| fg / fn / dp | What | Note |
|---|---|---|
| 60 / 254 / 45 | COP current | reads 0 when idle |
| 60 / 254 / **51** | Heat quantity **cooling** | you already have 47 (heating) and 55 (DHW), this is the missing third |
| 60 / 254 / 32 | Water pressure | `0x8000` when no sensor wired |
| 60 / 254 / 84, 85 | Source flow / return (evaporator) | |
| 60 / 7 / 1033-1035 | Runtime counters heating / cooling / DHW | S32, scale **0.1 h** |
| 10 / 1 / 2080-2083 | Operating hours + switching cycles, total and >50 % modulation | |
| 3 / 0 / 2040-2042 | System output setpoint heating / DHW / cooling | |
| 4 / 0 / 1009, 2043 | Aggregate output setpoint + request flag | |

**Two traps I ran into, handled with lambda filters so they cannot reach a dashboard:**

1. The output setpoints (`2040-2042`, `1009`) use **-127.0 as an invalid marker**, while **-100.0 is a perfectly valid reading** meaning "this channel is requesting nothing". Passing -127 through shows up as a phantom -12.7 % request. Filtered with `return (x <= -126.5f) ? NAN : x;`.
2. Water pressure returns `0x8000` when no sensor is fitted. Same treatment.

**Two naming problems in Hoval's own list, flagged in comments rather than silently fixed:**

- `dp 1034` is named *"Operating hours DHW"* in one place and *"Cooling operation running time"* in another; `dp 1035` is swapped the same way. The values decide it: on my unit 1034 = 45 h (cooling season started this August) and 1035 = 4348 h (daily DHW since 2021). So **1034 = cooling, 1035 = DHW**.
- `dp 2083` counts only starts **above 50 % modulation**, not all starts — on my unit 8461 vs. 20335 for `dp 2080`, a factor of 2.4. Worth labelling clearly, it is an easy metric to misread. (I had exactly this bug in my own cycle tracker for six weeks.)

**Verification:** every value was read via CAN GET on an UltraSource B comfort C17 (TTE-WEZ, commissioned 10/2021) and cross-checked two ways — against the lifetime energy counters (energy / runtime = 7.1 kW mean thermal output on a 17 kW unit, which only works out at scale 0.1 h) and against Hoval's own Modbus register list. The `1009 == max(2040, 2041, 2042)` relation holds in 6530 of 6587 samples (99.1 %); the rest is read-time skew during ramps.

Both files parse and the sensor `id`s are unique. I only touched `sensors_en.yaml` and `sensors_de.yaml` — **FR and IT would need a native speaker**, happy to add them if someone supplies the names, or feel free to push to this branch (`maintainer_can_modify` is on).

The raw evidence CSVs are in https://github.com/newstedaut/hoval_datapoints under `community_additions/WEZ/`, so nothing here depends on trusting my summary.